### PR TITLE
Don't attempt to lowercase a NULL

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -834,7 +834,9 @@ class RestController extends \CI_Controller
                 $method = $this->input->server('HTTP_X_HTTP_METHOD_OVERRIDE');
             }
 
-            $method = strtolower($method);
+            if ($method !== null) {
+                $method = strtolower($method);
+            }
         }
 
         if (empty($method)) {


### PR DESCRIPTION
Fixes PHP 8.1 deprecation notice when trying to `strtolower` `NULL`